### PR TITLE
Add related Raindrop bookmarks section to tagged pages

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,6 +2,11 @@
 # Full checks, mirroring the CI "build" and "test" jobs before code reaches GitHub.
 set -e
 
+if [ ! -f data/bookmarks.json ]; then
+  echo "pre-push: data/bookmarks.json missing — run 'npm run fetch:bookmarks' first" >&2
+  exit 1
+fi
+
 echo "pre-push: type checking and formatting..."
 npm run check
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Lint content
         run: npm run lint:content
         continue-on-error: true
+      - name: Fetch bookmarks
+        env:
+          BOOKMARKS_GITHUB_TOKEN: ${{ secrets.BOOKMARKS_GITHUB_TOKEN }}
+        run: npm run fetch:bookmarks
       - name: Build Quartz
         run: npx quartz build -d content -o public/content
       - name: Copy root pages
@@ -60,6 +64,10 @@ jobs:
           node-version: 22
       - name: Install Dependencies
         run: npm ci
+      - name: Fetch bookmarks
+        env:
+          BOOKMARKS_GITHUB_TOKEN: ${{ secrets.BOOKMARKS_GITHUB_TOKEN }}
+        run: npm run fetch:bookmarks
       - name: Run unit tests
         run: npm test
       - name: Install Playwright Browsers

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tsconfig.tsbuildinfo
 .obsidian/
 content/.obsidian/
 .quartz-cache/
+data/
 private/
 .replit
 replit.nix

--- a/e2e/content.spec.ts
+++ b/e2e/content.spec.ts
@@ -91,6 +91,22 @@ test.describe("Content (Quartz)", () => {
       await page.goto("/content/dotnet");
       await expect(page.locator(".content-meta")).toBeVisible();
     });
+
+    test("related bookmarks render on a tagged page", async ({ page }) => {
+      // Security.md is tagged `security`, which matches many Raindrop bookmarks
+      await page.goto("/content/security");
+      const bookmarks = page.locator(".related-bookmarks");
+      await expect(bookmarks).toBeVisible();
+      await expect(bookmarks.locator("a.external")).not.toHaveCount(0);
+    });
+
+    test("related bookmarks are absent on an untagged page", async ({
+      page,
+    }) => {
+      await page.goto("/content/dotnet");
+      await expect(page.locator("article").first()).toBeVisible();
+      await expect(page.locator(".related-bookmarks")).toHaveCount(0);
+    });
   });
 
   test.describe("SEO & meta tags", () => {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "check": "tsc --noEmit && npx prettier . --check",
     "format": "npx prettier . --write",
     "lint:content": "tsx scripts/lint-content.ts",
+    "fetch:bookmarks": "tsx scripts/fetch-bookmarks.ts",
     "test": "tsx --test",
     "test:coverage": "tsx --test --experimental-test-coverage",
     "test:e2e": "playwright test",

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -5,7 +5,7 @@ import * as Component from "./quartz/components";
 export const sharedPageComponents: SharedLayout = {
   head: Component.Head(),
   header: [],
-  afterBody: [],
+  afterBody: [Component.RelatedBookmarks()],
   footer: Component.Footer({
     links: {},
   }),

--- a/quartz/components/RelatedBookmarks.tsx
+++ b/quartz/components/RelatedBookmarks.tsx
@@ -1,0 +1,41 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import style from "./styles/relatedBookmarks.scss"
+import { classNames } from "../util/lang"
+import { formatDate } from "./Date"
+import { getRelatedBookmarks, loadTagIndex } from "../util/bookmarks"
+
+const RelatedBookmarks: QuartzComponent = ({
+  fileData,
+  displayClass,
+  cfg,
+}: QuartzComponentProps) => {
+  const tags = fileData.frontmatter?.tags
+  if (!tags || tags.length === 0) {
+    return null
+  }
+  const bookmarks = getRelatedBookmarks(loadTagIndex(), tags)
+  if (bookmarks.length === 0) {
+    return null
+  }
+  return (
+    <div class={classNames(displayClass, "related-bookmarks")}>
+      <h3>Related bookmarks ({bookmarks.length})</h3>
+      <ul>
+        {bookmarks.map((b) => (
+          <li>
+            <a href={b.link} class="external">
+              {b.title}
+            </a>
+            <span class="bookmark-meta">
+              {b.domain} · {formatDate(new Date(b.created), cfg.locale)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+RelatedBookmarks.css = style
+
+export default (() => RelatedBookmarks) satisfies QuartzComponentConstructor

--- a/quartz/components/RelatedBookmarks.tsx
+++ b/quartz/components/RelatedBookmarks.tsx
@@ -22,7 +22,7 @@ const RelatedBookmarks: QuartzComponent = ({
       <h3>Related bookmarks ({bookmarks.length})</h3>
       <ul>
         {bookmarks.map((b) => (
-          <li>
+          <li key={b._id}>
             <a href={b.link} class="external">
               {b.title}
             </a>

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -14,6 +14,7 @@ import Explorer from "./Explorer"
 import TagList from "./TagList"
 import Graph from "./Graph"
 import Backlinks from "./Backlinks"
+import RelatedBookmarks from "./RelatedBookmarks"
 import Search from "./Search"
 import Footer from "./Footer"
 import DesktopOnly from "./DesktopOnly"
@@ -40,6 +41,7 @@ export {
   TagList,
   Graph,
   Backlinks,
+  RelatedBookmarks,
   Search,
   Footer,
   DesktopOnly,

--- a/quartz/components/styles/relatedBookmarks.scss
+++ b/quartz/components/styles/relatedBookmarks.scss
@@ -1,0 +1,28 @@
+@use "../../styles/variables.scss" as *;
+
+.related-bookmarks {
+  & > h3 {
+    font-size: 1rem;
+    margin: 0;
+  }
+
+  & > ul {
+    list-style: none;
+    padding: 0;
+    margin: 0.5rem 0;
+
+    & > li {
+      margin: 0.4rem 0;
+
+      & > a {
+        background-color: transparent;
+      }
+
+      & > .bookmark-meta {
+        display: block;
+        font-size: 0.8rem;
+        color: var(--gray);
+      }
+    }
+  }
+}

--- a/quartz/util/bookmarks.test.ts
+++ b/quartz/util/bookmarks.test.ts
@@ -1,0 +1,93 @@
+import test, { describe } from "node:test"
+import assert from "node:assert"
+import { buildTagIndex, getRelatedBookmarks, Bookmark, BookmarksFile } from "./bookmarks"
+
+function makeBookmark(overrides: Partial<Bookmark>): Bookmark {
+  return {
+    _id: 1,
+    link: "https://example.com",
+    title: "Example",
+    excerpt: "",
+    tags: [],
+    created: "2026-01-01T00:00:00.000Z",
+    domain: "example.com",
+    ...overrides,
+  }
+}
+
+const azureOld = makeBookmark({
+  _id: 1,
+  title: "Azure old",
+  tags: ["azure"],
+  created: "2025-01-01T00:00:00.000Z",
+})
+const azureNew = makeBookmark({
+  _id: 2,
+  title: "Azure new",
+  tags: ["Azure"],
+  created: "2026-06-01T00:00:00.000Z",
+})
+const both = makeBookmark({
+  _id: 3,
+  title: "Azure and security",
+  tags: ["azure", "security"],
+  created: "2026-03-01T00:00:00.000Z",
+})
+const softwareDev = makeBookmark({
+  _id: 4,
+  title: "Software development",
+  tags: ["software development"],
+  created: "2026-02-01T00:00:00.000Z",
+})
+
+const fixture: BookmarksFile = {
+  collections: [
+    { bookmarks: [azureOld, azureNew] },
+    // azureOld appears again in a second collection to exercise dedupe
+    { bookmarks: [azureOld, both, softwareDev] },
+  ],
+}
+
+describe("buildTagIndex", () => {
+  test("flattens collections and dedupes bookmarks by _id", () => {
+    const index = buildTagIndex(fixture)
+    const azure = index.get("azure")!
+    assert.strictEqual(azure.length, 3)
+    assert.strictEqual(azure.filter((b) => b._id === azureOld._id).length, 1)
+  })
+
+  test("indexes tags case-insensitively, including tags with spaces", () => {
+    const index = buildTagIndex(fixture)
+    assert(index.get("azure")!.some((b) => b._id === azureNew._id))
+    assert.strictEqual(index.get("software development")!.length, 1)
+  })
+
+  test("sorts each bucket by created descending", () => {
+    const index = buildTagIndex(fixture)
+    assert.deepStrictEqual(
+      index.get("azure")!.map((b) => b.title),
+      ["Azure new", "Azure and security", "Azure old"],
+    )
+  })
+})
+
+describe("getRelatedBookmarks", () => {
+  const index = buildTagIndex(fixture)
+
+  test("matches page tags case-insensitively", () => {
+    assert.strictEqual(getRelatedBookmarks(index, ["AZURE"]).length, 3)
+  })
+
+  test("dedupes a bookmark matching multiple page tags and sorts newest first", () => {
+    const results = getRelatedBookmarks(index, ["azure", "security"])
+    assert.deepStrictEqual(
+      results.map((b) => b.title),
+      ["Azure new", "Azure and security", "Azure old"],
+    )
+  })
+
+  test("returns empty for unknown tags or no tags", () => {
+    assert.deepStrictEqual(getRelatedBookmarks(index, ["nonexistent"]), [])
+    assert.deepStrictEqual(getRelatedBookmarks(index, []), [])
+  })
+})

--- a/quartz/util/bookmarks.ts
+++ b/quartz/util/bookmarks.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "fs"
+import path from "path"
+
+export interface Bookmark {
+  _id: number
+  link: string
+  title: string
+  excerpt: string
+  tags: string[]
+  created: string
+  domain: string
+}
+
+export interface BookmarksFile {
+  date?: string
+  collections: { bookmarks: Bookmark[] }[]
+}
+
+export type TagIndex = Map<string, Bookmark[]>
+
+const byCreatedDesc = (a: Bookmark, b: Bookmark) => b.created.localeCompare(a.created)
+
+export function buildTagIndex(raw: BookmarksFile): TagIndex {
+  const seen = new Set<number>()
+  const index: TagIndex = new Map()
+  for (const bookmark of raw.collections.flatMap((c) => c.bookmarks)) {
+    if (seen.has(bookmark._id)) continue
+    seen.add(bookmark._id)
+    for (const tag of bookmark.tags ?? []) {
+      const key = tag.toLowerCase().trim()
+      const bucket = index.get(key)
+      if (bucket) {
+        bucket.push(bookmark)
+      } else {
+        index.set(key, [bookmark])
+      }
+    }
+  }
+  for (const bucket of index.values()) {
+    bucket.sort(byCreatedDesc)
+  }
+  return index
+}
+
+export function getRelatedBookmarks(index: TagIndex, pageTags: string[]): Bookmark[] {
+  const seen = new Set<number>()
+  const matches: Bookmark[] = []
+  for (const tag of pageTags) {
+    for (const bookmark of index.get(tag.toLowerCase().trim()) ?? []) {
+      if (seen.has(bookmark._id)) continue
+      seen.add(bookmark._id)
+      matches.push(bookmark)
+    }
+  }
+  return matches.sort(byCreatedDesc)
+}
+
+let cachedIndex: TagIndex | undefined
+export function loadTagIndex(): TagIndex {
+  if (cachedIndex) return cachedIndex
+  const dataPath = path.join(process.cwd(), "data", "bookmarks.json")
+  let raw: BookmarksFile
+  try {
+    raw = JSON.parse(readFileSync(dataPath, "utf-8"))
+  } catch (err) {
+    throw new Error(
+      `data/bookmarks.json is missing or unreadable. Run \`npm run fetch:bookmarks\` before building (in CI, ensure the BOOKMARKS_GITHUB_TOKEN secret is set). Original error: ${err instanceof Error ? err.message : err}`,
+    )
+  }
+  if (!Array.isArray(raw.collections)) {
+    throw new Error("data/bookmarks.json has an unexpected shape — missing collections array.")
+  }
+  cachedIndex = buildTagIndex(raw)
+  return cachedIndex
+}

--- a/quartz/util/bookmarks.ts
+++ b/quartz/util/bookmarks.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs"
-import path from "path"
+import { readFileSync } from "node:fs"
+import path from "node:path"
 
 export interface Bookmark {
   _id: number
@@ -68,7 +68,7 @@ export function loadTagIndex(): TagIndex {
     )
   }
   if (!Array.isArray(raw.collections)) {
-    throw new Error("data/bookmarks.json has an unexpected shape — missing collections array.")
+    throw new TypeError("data/bookmarks.json has an unexpected shape — missing collections array.")
   }
   cachedIndex = buildTagIndex(raw)
   return cachedIndex

--- a/scripts/fetch-bookmarks.ts
+++ b/scripts/fetch-bookmarks.ts
@@ -4,30 +4,34 @@
 // build to consume. Auth: BOOKMARKS_GITHUB_TOKEN env var (CI), falling back to the
 // local `gh` CLI token. Exits non-zero on any failure so builds fail loudly.
 
-import { execFileSync } from "child_process";
-import { mkdirSync, writeFileSync } from "fs";
-import path from "path";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
 
 const REPO = "tjrobinson/raindrop-automation";
 const API_URL = `https://api.github.com/repos/${REPO}/contents/bookmarks.json?ref=main`;
 const OUTPUT_PATH = path.join(process.cwd(), "data", "bookmarks.json");
 
+// Absolute paths only — no $PATH resolution, so `gh` can't be shadowed (SonarCloud S4036)
+const GH_LOCATIONS = [
+  "/opt/homebrew/bin/gh",
+  "/usr/local/bin/gh",
+  "/usr/bin/gh",
+];
+
 function resolveToken(): string {
   const envToken = process.env.BOOKMARKS_GITHUB_TOKEN?.trim();
   if (envToken) return envToken;
-  try {
-    const ghToken = execFileSync("gh", ["auth", "token"], {
-      encoding: "utf-8",
-      // Fixed, root-owned directories only, so `gh` can't be shadowed via a
-      // writable PATH entry (SonarCloud S4036).
-      env: {
-        ...process.env,
-        PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
-      },
-    }).trim();
-    if (ghToken) return ghToken;
-  } catch {
-    // fall through to the error below
+  const gh = GH_LOCATIONS.find((location) => existsSync(location));
+  if (gh) {
+    try {
+      const ghToken = execFileSync(gh, ["auth", "token"], {
+        encoding: "utf-8",
+      }).trim();
+      if (ghToken) return ghToken;
+    } catch {
+      // fall through to the error below
+    }
   }
   console.error(
     "fetch-bookmarks: no GitHub token available. Set BOOKMARKS_GITHUB_TOKEN or run `gh auth login`.",
@@ -48,7 +52,6 @@ async function main() {
   });
 
   if (!response.ok) {
-    const body = await response.text();
     console.error(
       `fetch-bookmarks: GitHub API returned ${response.status} for ${REPO}.`,
     );
@@ -57,8 +60,6 @@ async function main() {
         "fetch-bookmarks: a 404 usually means the token lacks access — check the PAT has read-only Contents permission on tjrobinson/raindrop-automation.",
       );
     }
-    // JSON.stringify escapes control characters so the response can't forge log lines
-    console.error(JSON.stringify(body.slice(0, 500)));
     process.exit(1);
   }
 
@@ -93,7 +94,9 @@ async function main() {
   );
 }
 
-main().catch((err) => {
+try {
+  await main();
+} catch (err) {
   console.error(`fetch-bookmarks: ${err instanceof Error ? err.message : err}`);
   process.exit(1);
-});
+}

--- a/scripts/fetch-bookmarks.ts
+++ b/scripts/fetch-bookmarks.ts
@@ -18,6 +18,12 @@ function resolveToken(): string {
   try {
     const ghToken = execFileSync("gh", ["auth", "token"], {
       encoding: "utf-8",
+      // Fixed, root-owned directories only, so `gh` can't be shadowed via a
+      // writable PATH entry (SonarCloud S4036).
+      env: {
+        ...process.env,
+        PATH: "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
+      },
     }).trim();
     if (ghToken) return ghToken;
   } catch {
@@ -51,7 +57,8 @@ async function main() {
         "fetch-bookmarks: a 404 usually means the token lacks access — check the PAT has read-only Contents permission on tjrobinson/raindrop-automation.",
       );
     }
-    console.error(body.slice(0, 500));
+    // JSON.stringify escapes control characters so the response can't forge log lines
+    console.error(JSON.stringify(body.slice(0, 500)));
     process.exit(1);
   }
 
@@ -76,8 +83,13 @@ async function main() {
     (n, c) => n + (c.bookmarks?.length ?? 0),
     0,
   );
+  // Re-parse the snapshot date so the logged value can't carry control characters
+  const snapshotMs = Date.parse(data.date ?? "");
+  const snapshot = Number.isNaN(snapshotMs)
+    ? "unknown"
+    : new Date(snapshotMs).toISOString();
   console.log(
-    `fetch-bookmarks: wrote ${count} bookmarks (snapshot ${data.date ?? "unknown"}) to ${path.relative(process.cwd(), OUTPUT_PATH)}`,
+    `fetch-bookmarks: wrote ${count} bookmarks (snapshot ${snapshot}) to ${path.relative(process.cwd(), OUTPUT_PATH)}`,
   );
 }
 

--- a/scripts/fetch-bookmarks.ts
+++ b/scripts/fetch-bookmarks.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env tsx
+// Fetches bookmarks.json from the private tjrobinson/raindrop-automation repo via the
+// GitHub contents API and writes it to data/bookmarks.json (gitignored) for the site
+// build to consume. Auth: BOOKMARKS_GITHUB_TOKEN env var (CI), falling back to the
+// local `gh` CLI token. Exits non-zero on any failure so builds fail loudly.
+
+import { execFileSync } from "child_process";
+import { mkdirSync, writeFileSync } from "fs";
+import path from "path";
+
+const REPO = "tjrobinson/raindrop-automation";
+const API_URL = `https://api.github.com/repos/${REPO}/contents/bookmarks.json?ref=main`;
+const OUTPUT_PATH = path.join(process.cwd(), "data", "bookmarks.json");
+
+function resolveToken(): string {
+  const envToken = process.env.BOOKMARKS_GITHUB_TOKEN?.trim();
+  if (envToken) return envToken;
+  try {
+    const ghToken = execFileSync("gh", ["auth", "token"], {
+      encoding: "utf-8",
+    }).trim();
+    if (ghToken) return ghToken;
+  } catch {
+    // fall through to the error below
+  }
+  console.error(
+    "fetch-bookmarks: no GitHub token available. Set BOOKMARKS_GITHUB_TOKEN or run `gh auth login`.",
+  );
+  process.exit(1);
+}
+
+async function main() {
+  const token = resolveToken();
+  const response = await fetch(API_URL, {
+    headers: {
+      // The raw media type is required: the contents API only serves files
+      // between 1 and 100 MB as raw content, and bookmarks.json is multi-MB.
+      Accept: "application/vnd.github.raw+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    console.error(
+      `fetch-bookmarks: GitHub API returned ${response.status} for ${REPO}.`,
+    );
+    if (response.status === 404) {
+      console.error(
+        "fetch-bookmarks: a 404 usually means the token lacks access — check the PAT has read-only Contents permission on tjrobinson/raindrop-automation.",
+      );
+    }
+    console.error(body.slice(0, 500));
+    process.exit(1);
+  }
+
+  const raw = await response.text();
+  let data: { date?: string; collections?: { bookmarks?: unknown[] }[] };
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    console.error("fetch-bookmarks: response was not valid JSON.");
+    process.exit(1);
+  }
+  if (!Array.isArray(data.collections)) {
+    console.error(
+      "fetch-bookmarks: unexpected JSON shape — missing collections array.",
+    );
+    process.exit(1);
+  }
+
+  mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  writeFileSync(OUTPUT_PATH, raw);
+  const count = data.collections.reduce(
+    (n, c) => n + (c.bookmarks?.length ?? 0),
+    0,
+  );
+  console.log(
+    `fetch-bookmarks: wrote ${count} bookmarks (snapshot ${data.date ?? "unknown"}) to ${path.relative(process.cwd(), OUTPUT_PATH)}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(`fetch-bookmarks: ${err instanceof Error ? err.message : err}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Pages with tags now show a **"Related bookmarks (N)"** section after the article body, listing all Raindrop bookmarks that share a tag with the page (e.g. a page tagged `azure` lists every bookmark tagged `azure`). Bookmarks are matched case-insensitively, deduped across Raindrop collections, and sorted newest first, each showing title, domain, and date. Untagged pages are unchanged, and no Obsidian markdown files were modified.

## How it works

- `npm run fetch:bookmarks` (new `scripts/fetch-bookmarks.ts`) downloads `bookmarks.json` from the private `tjrobinson/raindrop-automation` repo via the GitHub contents API into gitignored `data/`. Auth: `BOOKMARKS_GITHUB_TOKEN` in CI, `gh auth token` fallback locally.
- `quartz/util/bookmarks.ts` builds a tag → bookmarks index once per build; it throws with an actionable error if the data file is missing, so the site can never deploy without bookmark data.
- New `RelatedBookmarks` Quartz component wired into the shared `afterBody` layout slot.
- CI: both the build and test jobs fetch bookmarks before building (the test job needs it because Playwright's webServer rebuilds the site). Requires the `BOOKMARKS_GITHUB_TOKEN` repo secret (fine-grained PAT, Contents read-only on raindrop-automation) — already configured.
- `.githooks/pre-push` fails fast if `data/bookmarks.json` is missing.

## Testing

- 6 new unit tests for the tag-index logic (flattening, dedupe, case-insensitivity, sort order).
- 2 new Playwright tests: section renders with external links on `/content/security`, absent on the untagged `/content/dotnet`.
- Verified locally: Security page lists 612 unique bookmarks (raw tag count is 766; 154 are cross-collection duplicates, confirmed via jq), newest first, styled correctly in the dark theme with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)