### PR TITLE
Let PR builds proceed without a bookmarks token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Fetch bookmarks
         env:
           BOOKMARKS_GITHUB_TOKEN: ${{ secrets.BOOKMARKS_GITHUB_TOKEN }}
+          # Dependabot and fork PRs never receive repository secrets, so let those
+          # builds continue without bookmarks. Pushes to main stay strict.
+          BOOKMARKS_OPTIONAL: ${{ github.event_name == 'pull_request' && '1' || '' }}
         run: npm run fetch:bookmarks
       - name: Build Quartz
         run: npx quartz build -d content -o public/content
@@ -67,6 +70,7 @@ jobs:
       - name: Fetch bookmarks
         env:
           BOOKMARKS_GITHUB_TOKEN: ${{ secrets.BOOKMARKS_GITHUB_TOKEN }}
+          BOOKMARKS_OPTIONAL: ${{ github.event_name == 'pull_request' && '1' || '' }}
         run: npm run fetch:bookmarks
       - name: Run unit tests
         run: npm test

--- a/e2e/content.spec.ts
+++ b/e2e/content.spec.ts
@@ -1,4 +1,18 @@
 import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+
+// Bookmarks come from a private repo and need a token, so PR builds without
+// repository secrets (Dependabot, forks) legitimately have an empty snapshot.
+function hasBookmarkData(): boolean {
+  try {
+    const raw: { collections?: { bookmarks?: unknown[] }[] } = JSON.parse(
+      readFileSync("data/bookmarks.json", "utf-8"),
+    );
+    return (raw.collections ?? []).some((c) => (c.bookmarks?.length ?? 0) > 0);
+  } catch {
+    return false;
+  }
+}
 
 test.describe("Content (Quartz)", () => {
   test.describe("Index page", () => {
@@ -93,6 +107,10 @@ test.describe("Content (Quartz)", () => {
     });
 
     test("related bookmarks render on a tagged page", async ({ page }) => {
+      test.skip(
+        !hasBookmarkData(),
+        "no bookmark snapshot available (BOOKMARKS_GITHUB_TOKEN not set)",
+      );
       // Security.md is tagged `security`, which matches many Raindrop bookmarks
       await page.goto("/content/security");
       const bookmarks = page.locator(".related-bookmarks");

--- a/scripts/fetch-bookmarks.ts
+++ b/scripts/fetch-bookmarks.ts
@@ -2,7 +2,10 @@
 // Fetches bookmarks.json from the private tjrobinson/raindrop-automation repo via the
 // GitHub contents API and writes it to data/bookmarks.json (gitignored) for the site
 // build to consume. Auth: BOOKMARKS_GITHUB_TOKEN env var (CI), falling back to the
-// local `gh` CLI token. Exits non-zero on any failure so builds fail loudly.
+// local `gh` CLI token. Exits non-zero on any failure so builds fail loudly, unless
+// BOOKMARKS_OPTIONAL is set and no token is available — then an empty snapshot is
+// written so the build can continue. CI sets that only for pull requests, where
+// Dependabot and fork runs never receive repository secrets.
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
@@ -19,7 +22,7 @@ const GH_LOCATIONS = [
   "/usr/bin/gh",
 ];
 
-function resolveToken(): string {
+function resolveToken(): string | undefined {
   const envToken = process.env.BOOKMARKS_GITHUB_TOKEN?.trim();
   if (envToken) return envToken;
   const gh = GH_LOCATIONS.find((location) => existsSync(location));
@@ -30,17 +33,34 @@ function resolveToken(): string {
       }).trim();
       if (ghToken) return ghToken;
     } catch {
-      // fall through to the error below
+      // fall through — the caller decides whether a missing token is fatal
     }
   }
-  console.error(
-    "fetch-bookmarks: no GitHub token available. Set BOOKMARKS_GITHUB_TOKEN or run `gh auth login`.",
-  );
-  process.exit(1);
+  return undefined;
+}
+
+// Written when the token is absent but bookmarks are optional, so downstream
+// consumers get a valid (empty) index instead of a missing-file error.
+function writeEmptySnapshot() {
+  mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+  writeFileSync(OUTPUT_PATH, JSON.stringify({ collections: [] }));
 }
 
 async function main() {
   const token = resolveToken();
+  if (!token) {
+    if (process.env.BOOKMARKS_OPTIONAL?.trim()) {
+      console.warn(
+        "fetch-bookmarks: no GitHub token available — writing an empty snapshot because BOOKMARKS_OPTIONAL is set. Related bookmarks will be absent from this build.",
+      );
+      writeEmptySnapshot();
+      return;
+    }
+    console.error(
+      "fetch-bookmarks: no GitHub token available. Set BOOKMARKS_GITHUB_TOKEN or run `gh auth login`.",
+    );
+    process.exit(1);
+  }
   const response = await fetch(API_URL, {
     headers: {
       // The raw media type is required: the contents API only serves files


### PR DESCRIPTION
## Problem

Every Dependabot PR fails its `build` job, blocking #1055 and #1054:

```
fetch-bookmarks: no GitHub token available. Set BOOKMARKS_GITHUB_TOKEN or run `gh auth login`.
##[error]Process completed with exit code 1.
```

GitHub never passes repository Actions secrets to Dependabot- or fork-triggered
workflow runs. `BOOKMARKS_GITHUB_TOKEN` is configured as an Actions secret (and
there are no Dependabot secrets), so it arrives empty and `fetch-bookmarks`
exits 1 before the site is ever built. This has blocked every Dependabot PR
since the bookmarks feature landed in cf11970e.

## Fix

Add a `BOOKMARKS_OPTIONAL` escape hatch to `scripts/fetch-bookmarks.ts`: when no
token can be resolved *and* the flag is set, write an empty snapshot
(`{"collections":[]}`) and continue instead of failing.

The workflow sets it only for `pull_request` events, so **pushes to `main` stay
strict** — if the secret ever goes missing, a deploy still fails loudly rather
than silently publishing without bookmarks. PRs from this repo's own branches
do get the secret, so they fetch real data as before.

`RelatedBookmarks` already renders nothing for an empty index, so the build
degrades cleanly. The e2e test asserting bookmarks render now skips when the
snapshot is empty, and runs normally wherever real data is present.

## Verification

Locally, with the `gh` fallback disabled to simulate CI:

- no token, no flag → exits 1 with the original error (unchanged)
- no token, `BOOKMARKS_OPTIONAL=1` → warns, writes empty snapshot, exits 0
- `npx quartz build` against the empty snapshot → 486 files emitted, no error
- bookmark e2e tests with empty snapshot → 1 skipped, 1 passed
- bookmark e2e tests with real snapshot restored → 2 passed
- full pre-push suite → `npm run check`, 91 unit tests, 33 e2e tests all pass

## Alternative considered

Adding `BOOKMARKS_GITHUB_TOKEN` as a *Dependabot* secret would also work, but it
exposes a PAT for a private repo to the install scripts of whatever dependency
is being bumped. Not worth it to render bookmarks in a PR preview.

## After merging

Re-run the failed checks on #1055 and #1054 — `pull_request` workflows run from
the merge commit, so both will pick this up without needing a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)